### PR TITLE
Add NewsPleaseTextLoader for structured news article extraction

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -26,6 +26,7 @@ dependencies = [
     "tavily-python>=0.7.23",
     "tldextract>=5.3.1",
     "torch>=2.10.0",
+    "news-please>=1.6.0",
     "trafilatura>=2.0.0",
     "transformers>=5.3.0",
 ]

--- a/src/config.py
+++ b/src/config.py
@@ -18,6 +18,10 @@ HARDCODED_TEXT = "" #"""What I'm suggesting is we have a sort of an eco-evangeli
 from other_models import TextFromURLLoader, TrafilaturaTextLoader
 TEXT_LOADER: TextFromURLLoader = TrafilaturaTextLoader()
 
+# news-please — structured extractor with broad news site support (pip install news-please):
+# from other_models import NewsPleaseTextLoader
+# TEXT_LOADER: TextFromURLLoader = NewsPleaseTextLoader()
+
 from langchain.text_splitter import RecursiveCharacterTextSplitter
 TEXT_SPLITTER = RecursiveCharacterTextSplitter(chunk_size=1000, chunk_overlap=200)
 

--- a/src/other_models.py
+++ b/src/other_models.py
@@ -91,6 +91,31 @@ class TrafilaturaTextLoader(TextFromURLLoader):
         self.show_text(text)
         return text
 
+class NewsPleaseTextLoader(TextFromURLLoader):
+    """news-please — structured news article extractor with broad site support.
+    Extracts maintext, title, authors, and publish date from news URLs.
+    Install: pip install news-please"""
+    def __init__(self, include_title: bool = True) -> None:
+        super().__init__()
+        try:
+            from newsplease import NewsPlease
+        except ImportError:
+            raise ImportError("Please install the news-please package: pip install news-please")
+        self.NewsPlease = NewsPlease
+        self.include_title = include_title
+
+    def load_text(self, url: str) -> str:
+        article = self.NewsPlease.from_url(url)
+        if article is None:
+            raise ValueError(f"news-please failed to fetch article from {url}.")
+        text = article.maintext
+        if not text:
+            raise ValueError(f"news-please extracted no text from {url}.")
+        if self.include_title and article.title:
+            text = f"{article.title}\n\n{text}"
+        self.show_text(text)
+        return text
+
 
 
 class SourcesFinder(ABC):


### PR DESCRIPTION
Integrates the news-please library as an optional TextFromURLLoader
implementation. Extracts maintext and optionally prepends the article
title. Adds news-please>=1.6.0 to project dependencies and a
commented-out example in config.py.

https://claude.ai/code/session_01KjX6w6SwMnfh9rKtNHJf2E